### PR TITLE
Remove 'isset' for flattr param

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -30,7 +30,7 @@
       </li>
     </ul>
 
-    {{ if isset .Site.Params "flattr" }}
+    {{ if .Site.Params "flattr" }}
     <p><script id='flattr'>
       (function(id){
         var s = document.getElementById(id);


### PR DESCRIPTION
When the value if flattr is "", '{{ if isset .Site.Params "flattr" }}' returns true.

Also tried using '{{ with .Site.Params.flattr }}' but it does not work
because it re-scopes '{{ . }}', removing access to '.Site.Title'.